### PR TITLE
Fix typo in woff files url loader

### DIFF
--- a/webpack/loaders.js
+++ b/webpack/loaders.js
@@ -13,7 +13,7 @@ module.exports = [
         loader: 'raw'
     }, {
         test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-        loader: 'url-loader?limit=10000&minetype=application/font-woff'
+        loader: 'url-loader?limit=10000&mimetype=application/font-woff'
     }, {
         test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         loader: 'file-loader'


### PR DESCRIPTION
It seems like you wanted to put a `mime-type`, not a `mine-type` here :-)

(I'm totally noob with webpack currently, so I may be wrong, but it caught my eye :))