### PR TITLE
No need to globally install webpack / typescript / typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ And this all with sourcemaps in production support!!
 ### Install
 
 ```sh
-npm i webpack typings typescript -g
 git clone git@github.com/brechtbilliet/angular-typescript-webpack.git
 cd angular-typescript-webpack
 npm install


### PR DESCRIPTION
Since the tools are already provided [in `package.json`](https://github.com/brechtbilliet/angular-typescript-webpack/blob/master/package.json#L53)
Simply running `npm install && npm start` should be enough.

And as a personal POV, I prefer enforcing tooling version in the `package.json` rather than sharing this amongst every of my projects (which may require different versions) :-)